### PR TITLE
Added support to play audio on the radio source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Device(location)
 ```python
     SetStandby(standbyRequested) #bool
     Play() #starts playback
+    Play(track_details) #start playing `track_details`
     Stop() #stops playback
     Pause() #pauses playback
     Skip(offset) #positive or negative integer
@@ -118,6 +119,19 @@ Device(location)
   "title": "Violin Sonata No. 2 in A Minor, BWV 1003 (Arr. for Viola da gamba) : Violin Sonata No. 2 in A Minor, BWV 1003 (Arr. for Viola da gamba): II. Fuga",
   "sampleRate": 44100
 }
+```
+
+##### Playing A Track
+
+Use this to play a short audio track, a podcast Uri or radio station Uri. The audio will be played using the radio source of the device. The `trackDetails` object should be the same as the one described in the `TrackInfo` section above. 
+
+```python
+    trackDetails = {}
+    trackDetails["uri"] = "http://opml.radiotime.com/Tune.ashx?id=s122119"
+    trackDetails["title"] = 'Linn Radio (Eclectic Music)'
+    trackDetails["albumArtwork"] = 'http://cdn-radiotime-logos.tunein.com/s122119q.png'
+
+    openhomeDevice.Play(trackDetails)
 ```
 
 ## Example

--- a/openhomedevice/Device.py
+++ b/openhomedevice/Device.py
@@ -7,7 +7,6 @@ from openhomedevice.Soap import soapRequest
 
 import xml.etree.ElementTree as etree
 
-
 class Device(object):
 
     def __init__(self, location):
@@ -76,6 +75,23 @@ class Device(object):
                 return self.PlayRadio()
             if source["type"] == "Playlist":
                 return self.PlayPlaylist()
+
+    def Play(self, track_details):
+        service = self.rootDevice.Device().Service("urn:av-openhome-org:serviceId:Radio")
+
+        didl_lite = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">' \
+                    '<item id="" parentID="" restricted="True">' \
+                    '<dc:title>' + track_details['title'] + '</dc:title>' \
+                    '<res protocolInfo="*:*:*:*">' + track_details['uri'] + '</res>' \
+                    '<upnp:albumArtURI>' + track_details['albumArtwork'] + '</upnp:albumArtURI>' \
+                    '<upnp:class>object.item.audioItem</upnp:class>' \
+                    '</item>' \
+                    '</DIDL-Lite>'
+
+        channelValue = ("<Uri>%s</Uri><Metadata>%s</Metadata>" % (track_details["uri"], didl_lite))
+        soapRequest(service.ControlUrl(), service.Type(), "SetChannel", channelValue)
+
+        self.PlayRadio()
 
     def Stop(self):
         if self.HasTransportService():
@@ -292,3 +308,7 @@ class Device(object):
         service = self.rootDevice.Device().Service("urn:av-openhome-org:serviceId:Config")
         configValue = ("<Key>%s</Key><Value>%s</Value>" % (key, value))
         soapRequest(service.ControlUrl(), service.Type(), "SetValue", configValue)
+
+    def GetLog(self):
+        service = self.rootDevice.Device().Service("urn:av-openhome-org:serviceId:Debug")
+        return soapRequest(service.ControlUrl(), service.Type(), "GetLog", "").decode('utf-8').split("\n")

--- a/openhomedevice/TrackInfoParser.py
+++ b/openhomedevice/TrackInfoParser.py
@@ -92,9 +92,9 @@ class TrackInfoParser(object):
     def FindElementAttributeValue(self, itemElement, itemKey, itemAttribute):
         namespaces = {
                 'DIDL-Lite': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
-		'upnp': 'urn:schemas-upnp-org:metadata-1-0/upnp/',
+                'upnp': 'urn:schemas-upnp-org:metadata-1-0/upnp/',
                 'dc': 'http://purl.org/dc/elements/1.1/'
-	}
+        }
 
         value = itemElement.find(itemKey, namespaces)
         parsedValue = None
@@ -109,9 +109,9 @@ class TrackInfoParser(object):
     def FindElementValue(self, itemElement, itemKey, isArray):
         namespaces = {
                 'DIDL-Lite': 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/',
-		'upnp': 'urn:schemas-upnp-org:metadata-1-0/upnp/',
+                'upnp': 'urn:schemas-upnp-org:metadata-1-0/upnp/',
                 'dc': 'http://purl.org/dc/elements/1.1/'
-	}
+        }
 
         items = itemElement.findall(itemKey, namespaces)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
   name = 'openhomedevice',
   packages = ['openhomedevice'],
-  version = '0.4.3',
+  version = '0.5.0',
   description = 'Provides an API for requesting information from an Openhome device',
   author = 'Barry John Williams',
   author_email = 'barry@bjw.me.uk',


### PR DESCRIPTION
Adds support to play a music track, podcast or radio station by a single `Play(track_details)` function where `track_details` is the same object as returned by `TrackInfo`

For example, this will play Linn Radio:

```python
    trackDetails = {}
    trackDetails["uri"] = "http://opml.radiotime.com/Tune.ashx?id=s122119"
    trackDetails["title"] = 'Linn Radio (Eclectic Music)'
    trackDetails["albumArtwork"] = 'http://cdn-radiotime-logos.tunein.com/s122119q.png'

    openhomeDevice.Play(trackDetails)
```

Fixes #6 