### PR TITLE
Remove lxml dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
   packages=setuptools.find_packages(),
   download_url = 'https://github.com/bazwilliams/openhomedevice/tarball/2.1',
   keywords = ['upnp', 'dlna', 'openhome', 'linn', 'ds', 'music', 'render', 'async'],
-  install_requires = ['async_upnp_client>=0.40', 'lxml>=4.8.0'],
+  install_requires = ['async_upnp_client>=0.40'],
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The library has a dependency on lxml, which is not required since all XML features, used in the library are supported by built-in Python functionality. LXML adds about 20+ MD size to the docker image of any app, using it and is not easily buildable for amsll home automation controllers. In my case, I have to build for arm32v7.

This small fix removes the dependency, while keeping the library functional