### PR TITLE
Bump version to 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name = 'openhomedevice',
-  version = '2.4.1',
+  version = '2.5',
   author = 'Barry John Williams',
   author_email = 'barry@bjw.me.uk',
   description='Provides an API for requesting information from an Openhome device',
@@ -13,7 +13,7 @@ setuptools.setup(
   long_description_content_type="text/markdown",
   url='https://github.com/bazwilliams/openhomedevice',
   packages=setuptools.find_packages(exclude=["tests", "tools"]),
-  download_url = 'https://github.com/bazwilliams/openhomedevice/tarball/2.4.1',
+  download_url = 'https://github.com/bazwilliams/openhomedevice/tarball/2.5',
   keywords = ['upnp', 'dlna', 'openhome', 'linn', 'ds', 'music', 'render', 'async'],
   install_requires = ['async_upnp_client>=0.40'],
       classifiers=[


### PR DESCRIPTION
Releases the session and exception work that landed on master after 2.4.1.

- `Device(location, session=...)` reuses a caller's `aiohttp.ClientSession` and its connection pool. Home Assistant shares one session across integrations and expects to supply it. Passing nothing behaves exactly as 2.4.1 did.
- Every public method now raises from `openhomedevice.exceptions` (`OpenhomeError`, `OpenhomeConnectionError`, `OpenhomeTimeoutError`, `OpenhomeDeviceError`) instead of letting `async_upnp_client` types escape to callers.
- `python_requires` corrected from `>=3.6` to `>=3.10`, matching what `async_upnp_client` has required for some time.

No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)